### PR TITLE
fix: wrap counter in context

### DIFF
--- a/pages/paper-pages.typ
+++ b/pages/paper-pages.typ
@@ -44,7 +44,7 @@
 // 摘要部分页脚
 #let _set_paper_page_footer_pre(body) = {
     set page(
-        footer: {
+        footer: context {
         set align(center)
         
         grid(
@@ -66,7 +66,7 @@
 // 正文部分页脚
 #let _set_paper_page_footer_main(body) = {
     set page(
-        footer: {
+        footer: context {
         set align(center)
         
         grid(


### PR DESCRIPTION
When compiling in vscode, there is a compilation error:
```json
[{
	"resource": "/C:/Users/xxx/pages/paper-pages.typ",
	"owner": "_generated_diagnostic_collection_name_#0",
	"severity": 8,
	"message": "can only be used when context is known\n\nHint: try wrapping this in a context expression\n\nHint: the context expression should wrap everything that depends on this function",
	"source": "typst",
	"startLineNumber": 74,
	"startColumn": 50,
	"endLineNumber": 74,
	"endColumn": 76
}]
```
This would break the preview and compilation functionality in vscode, but works well when compiling using command `typst compile xxx.typ`, so I wrap the counter in context to make it work in vscode.