### PR TITLE
fix: 将机械学院开题报告模板迁移到 0.13 版本

### DIFF
--- a/variable/mse-proposal-variable.typ
+++ b/variable/mse-proposal-variable.typ
@@ -211,7 +211,11 @@
             columns: (5fr, 1fr, 5fr),
             line(length: 100%, stroke: 0.7pt + rgb(168, 193, 223)),
             text(font: songti, 10pt, baseline: -3pt, 
-            counter(page).display("1")
+            context {
+                    text(font: songti, 10pt, baseline: -3pt, 
+                        counter(page).display("1")
+                    )
+            },
             ),
             line(length: 100%, stroke: 0.7pt + rgb(168, 193, 223))
         )
@@ -246,9 +250,6 @@
     align(left + top)[
     #if with_annotation [
       #let huawenkaiti = ("Timse New Roman", "STKaiti")
-      #text(size: 10.5pt, fill: red, font:huawenkaiti)[
-        #h(0.1em)（用蓝、黑钢笔手写或小4号宋体字编辑，签名必须手写。可加页，A4纸双面打印）
-        ]
       ]
     ]
 


### PR DESCRIPTION
1. 参考 https://github.com/werifu/HUST-typst-template/pull/25#issue-2931998123 ，用 context expressions 包裹counter(page).display("1") 以继续显示页码
2. 删除表格中不必要的说明文字